### PR TITLE
removed forcing renew, no-autoupgrade

### DIFF
--- a/modoboa_installer/ssl.py
+++ b/modoboa_installer/ssl.py
@@ -104,7 +104,7 @@ class LetsEncryptCertificate(CertificateBackend):
                 self.hostname, self.config.get("letsencrypt", "email")))
         with open("/etc/cron.d/letsencrypt", "w") as fp:
             fp.write("0 */12 * * * root certbot renew "
-                     "--quiet --no-self-upgrade --force-renewal\n")
+                     "--quiet\n")
         cfg_file = "/etc/letsencrypt/renewal/{}.conf".format(self.hostname)
         pattern = "s/authenticator = standalone/authenticator = nginx/"
         utils.exec_cmd("perl -pi -e '{}' {}".format(pattern, cfg_file))


### PR DESCRIPTION
only renew, no force fix and do upgrades
https://github.com/modoboa/modoboa/issues/2129

**Description of the issue/feature this PR addresses:** 
certbot renew is being forced and no-upgrades allowed -> makes issues 

**Current behavior before PR:**
certbot renew is being forced and no-upgrades allowed -> makes issues 

**Desired behavior after PR is merged:**
should renew, but not being forced. should allow certbot upgrades

**_Third-Party Testing and Verification needed!_**
